### PR TITLE
Time expression annotations

### DIFF
--- a/src/dbv_anno_editor.js
+++ b/src/dbv_anno_editor.js
@@ -49,6 +49,7 @@
 	        },
 	        'keyterms': {}, 
 	        'persons': {},
+	        'time_expressions': {},
 	        'other': {}
 		};
 	

--- a/src/dbv_anno_viewer.js
+++ b/src/dbv_anno_viewer.js
@@ -161,7 +161,7 @@
 				this.block('persons', 'Persons', 'user', data.persons);
 				this.block('keyterms', 'Keyterms', 'tags', data.keyterms);
 				this.block('objects', 'Objects', 'crown', data.objects);
-				this.block('timespans', 'Timespans', 'calendar', data.timespans);
+				this.block('time_expressions', 'Time Expressions', 'calendar', data.time_expressions);
 			},
 
 			/**

--- a/src/style/text_layer_builder.css
+++ b/src/style/text_layer_builder.css
@@ -116,7 +116,7 @@
 	background-color: rgb(0, 107, 0);
 }
 
-.textLayer .dbv-annotation.timespans {
+.textLayer .dbv-annotation.time_expressions {
 	background-color: rgb(255, 192, 37);
 }
 
@@ -143,7 +143,7 @@
 }
 
 .dbv-annotations-hidden-objects  .dbv-annotation.objects,
-.dbv-annotations-hidden-timespans  .dbv-annotations-hidden-timespans,
+.dbv-annotations-hidden-time_expressions  .dbv-annotations-hidden-time_expressions,
 .dbv-annotations-hidden-keyterms  .dbv-annotation.keyterms,
 .dbv-annotations-hidden-persons  .dbv-annotation.persons,
 .dbv-annotations-hidden-locations  .dbv-annotation.locations,

--- a/src/style/viewer.css
+++ b/src/style/viewer.css
@@ -1952,7 +1952,7 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
     background-color: rgba(0, 0, 255, 0.3);
 }
 
-.dbv-colors-timespans {
+.dbv-colors-time_expressions {
     background-color: rgba(255, 192, 37, 0.3);
 }
 


### PR DESCRIPTION
This adds support for time expressions in PDF documents as created by cilantro's heideltime annotation worker. It is accompanied by [another PR with example data in the dai-book-viewer-docker repo](https://github.com/dainst/dai-book-viewer-docker/pull/1). To test this PR you can checkout that PR, run `docker-compose up` and check the example document at http://localhost:2223/?file=documents/example.pdf&pubid=example.json